### PR TITLE
Add VIR value 18 (4K 24Hz) to x40 video resolution map

### DIFF
--- a/uc_intg_anthemav/const.py
+++ b/uc_intg_anthemav/const.py
@@ -200,6 +200,11 @@ VIDEO_RESOLUTION_NAMES_X40 = {
     "14": "4K 60Hz",
     "15": "4K 50Hz",
     "16": "4K 24Hz",
+    # Values 17+ are not in the Anthem API doc (v5, Aug 2020).
+    # Empirically identified on MRX 540 8K (firmware HD.80/00.04).
+    # Anthem support was unable to provide the extended table.
+    # The difference between 16 and 18 (both 4K 24Hz, 3840x2160) is unknown.
+    "18": "4K 24Hz",
 }
 
 # x20 Front Panel Brightness (uses FPB command, not GCFPB)


### PR DESCRIPTION
## Summary

- Add undocumented VIR value 18 to the x40 video resolution map
- The Anthem API doc (v5, Aug 2020) only covers values 0-16. Newer MRX 540 8K firmware reports values beyond 16
- Anthem support was unable to provide the extended table and suggested contacting the HDMI board manufacturer
- Empirically identified using an Oppo UDP-203 with 4K HEVC BDMV content: VIR=18 reports 3840x2160 at 24fps
- The distinction between VIR 16 and 18 (both 4K 24Hz) is not yet understood — value 17 also remains unidentified

## Test plan

- [x] Confirmed VIR=18 with IRH=3840, IRV=2160 on MRX 540 8K (firmware HD.80/00.04)
- [x] Confirmed VIR=14 still reports correctly for standard 4K 60Hz (Apple TV)

🤖 Generated with [Claude Code](https://claude.com/claude-code)