### PR TITLE
Add dB volume presets and a retry wrapper for rejected commands

### DIFF
--- a/uc_intg_anthemav/const.py
+++ b/uc_intg_anthemav/const.py
@@ -46,6 +46,31 @@ CMD_VOLUME_PERCENT_DOWN = "PVDN"
 CMD_LEVEL_UP = "LUP"
 CMD_LEVEL_DOWN = "LDN"
 
+# Fixed-value dB preset commands exposed as simple_commands on the media_player.
+# UC doesn't support parameterized custom commands (only built-in VOLUME gets a
+# 0-100 entry field), so we expose a discrete set of dB targets. 5 dB steps
+# cover the receiver's full usable range.
+VOLUME_DB_PRESETS: dict[str, int] = {
+    **{f"VOLUME_DB_MINUS_{abs(db)}": db for db in range(-90, 0, 5)},
+    "VOLUME_DB_ZERO": 0,
+}
+
+# Generic retry defaults for AnthemDevice.send_with_retry(). Chosen to be
+# small enough not to pile up latency for commands the receiver rejects for
+# genuine reasons (wrong state, wrong value). Callers whose command needs a
+# longer window should pass explicit max_attempts / delay.
+RETRY_MAX_ATTEMPTS_DEFAULT = 3
+RETRY_DELAY_SECONDS_DEFAULT = 0.5
+
+# Volume (VOL/PVOL) retry budget. On cold-start, the MRX 540 rejects VOL
+# writes for several seconds after Z1POW1 while its internal state settles.
+# On a test with power-on volume -35 dB and user target -70 dB, the 8th
+# attempt was the first to succeed (~7.2 s after first send). Twelve
+# attempts at 1 s spacing gives ~12 s of coverage; raise this if longer
+# windows are observed on other receivers or power-on configurations.
+VOLUME_RETRY_MAX_ATTEMPTS = 12
+VOLUME_RETRY_DELAY_SECONDS = 1.0
+
 # Queries (Suffix with ?)
 QUERY_SUFFIX = "?"
 CMD_POWER_QUERY = CMD_POWER + QUERY_SUFFIX

--- a/uc_intg_anthemav/device.py
+++ b/uc_intg_anthemav/device.py
@@ -51,6 +51,10 @@ class AnthemDevice(PersistentConnectionDevice):
         self._input_count: int = 0
         self._model: str | None = None
         self._sensor_poll_tasks: dict[int, asyncio.Task] = {}
+        # Maps a command string (e.g. "Z1VOL-45") to (attempts_remaining,
+        # delay_seconds). Populated by send_with_retry(); drained by
+        # _process_response when the receiver returns !E<command>.
+        self._pending_retries: dict[str, tuple[int, float]] = {}
 
     @property
     def identifier(self) -> str:
@@ -156,6 +160,7 @@ class AnthemDevice(PersistentConnectionDevice):
         self._reader = None
         self._writer = None
         self._zone_states.clear()
+        self._pending_retries.clear()
         self.push_update()
 
     async def maintain_connection(self) -> None:
@@ -202,13 +207,62 @@ class AnthemDevice(PersistentConnectionDevice):
             _LOG.error("[%s] Error sending command %s: %s", self.log_id, command, err)
             return False
 
+    async def send_with_retry(
+        self,
+        command: str,
+        max_attempts: int = const.RETRY_MAX_ATTEMPTS_DEFAULT,
+        delay: float = const.RETRY_DELAY_SECONDS_DEFAULT,
+    ) -> bool:
+        """Send a command, retrying if the receiver rejects it with ``!E``.
+
+        Correlation is by the echoed command string: when ``!E<command>``
+        arrives in the read loop, the attempt counter for that exact command
+        is decremented and a re-send is scheduled ``delay`` seconds later.
+        After ``max_attempts`` rejections an error is logged and the registry
+        entry is dropped.
+
+        The initial send is awaited and its bool result returned. Retries
+        happen asynchronously in the response handler — this coroutine does
+        not block on them.
+        """
+        self._pending_retries[command] = (max_attempts, delay)
+        return await self._send_command(command)
+
+    async def _resend_after_delay(self, command: str, delay: float) -> None:
+        """Wait out the retry delay and re-emit the command."""
+        await asyncio.sleep(delay)
+        await self._send_command(command)
+
     async def _process_response(self, response: str) -> None:
         """Process a response from the receiver."""
         _LOG.debug("[%s] RECEIVED: %s", self.log_id, response)
 
-        if response.startswith(const.RESP_ERROR_INVALID_COMMAND) or response.startswith(
-            const.RESP_ERROR_EXECUTION_FAILED
-        ):
+        if response.startswith(const.RESP_ERROR_EXECUTION_FAILED):
+            # !E<echoed-command>. If the caller asked us to retry this
+            # command via send_with_retry(), decrement the attempt counter
+            # and schedule a re-send. Otherwise fall through to the warning.
+            echoed = response[len(const.RESP_ERROR_EXECUTION_FAILED):]
+            if echoed in self._pending_retries:
+                attempts, delay = self._pending_retries[echoed]
+                attempts -= 1
+                if attempts > 0:
+                    self._pending_retries[echoed] = (attempts, delay)
+                    _LOG.info(
+                        "[%s] Command '%s' rejected; retrying (%d attempts left)",
+                        self.log_id, echoed, attempts,
+                    )
+                    asyncio.create_task(self._resend_after_delay(echoed, delay))
+                else:
+                    _LOG.error(
+                        "[%s] Command '%s' rejected after all retries, giving up",
+                        self.log_id, echoed,
+                    )
+                    self._pending_retries.pop(echoed, None)
+                return
+            _LOG.warning("[%s] Device error: %s", self.log_id, response)
+            return
+
+        if response.startswith(const.RESP_ERROR_INVALID_COMMAND):
             _LOG.warning("[%s] Device error: %s", self.log_id, response)
             return
 
@@ -496,8 +550,15 @@ class AnthemDevice(PersistentConnectionDevice):
 
     async def set_volume(self, volume_db: int, zone: int = 1) -> bool:
         volume_db = max(-90, min(10, volume_db))
-        return await self._send_command(
-            self._get_zone_command(zone, const.CMD_VOLUME, volume_db)
+        # Skip no-op writes: the receiver returns !E when asked to set to
+        # its current value, which would otherwise trigger pointless retries.
+        zone_state = self._zone_states.get(zone)
+        if zone_state is not None and zone_state.volume_db == volume_db:
+            return True
+        return await self.send_with_retry(
+            self._get_zone_command(zone, const.CMD_VOLUME, volume_db),
+            max_attempts=const.VOLUME_RETRY_MAX_ATTEMPTS,
+            delay=const.VOLUME_RETRY_DELAY_SECONDS,
         )
 
     async def volume_up(self, zone: int = 1) -> bool:
@@ -519,8 +580,14 @@ class AnthemDevice(PersistentConnectionDevice):
     async def set_volume_percent(self, percent: int, zone: int = 1) -> bool:
         """Set volume as percentage (x40 series only)."""
         percent = max(0, min(100, percent))
-        return await self._send_command(
-            self._get_zone_command(zone, const.CMD_VOLUME_PERCENT, percent)
+        # Skip no-op writes (same rationale as set_volume).
+        zone_state = self._zone_states.get(zone)
+        if zone_state is not None and zone_state.volume_pct == percent:
+            return True
+        return await self.send_with_retry(
+            self._get_zone_command(zone, const.CMD_VOLUME_PERCENT, percent),
+            max_attempts=const.VOLUME_RETRY_MAX_ATTEMPTS,
+            delay=const.VOLUME_RETRY_DELAY_SECONDS,
         )
 
     async def volume_up_percent(self, zone: int = 1) -> bool:

--- a/uc_intg_anthemav/device.py
+++ b/uc_intg_anthemav/device.py
@@ -548,13 +548,19 @@ class AnthemDevice(PersistentConnectionDevice):
             self._get_zone_command(zone, const.CMD_POWER, const.VAL_OFF)
         )
 
-    async def set_volume(self, volume_db: int, zone: int = 1) -> bool:
+    async def set_volume(
+        self, volume_db: int, zone: int = 1, skip_if_redundant: bool = True
+    ) -> bool:
         volume_db = max(-90, min(10, volume_db))
         # Skip no-op writes: the receiver returns !E when asked to set to
         # its current value, which would otherwise trigger pointless retries.
-        zone_state = self._zone_states.get(zone)
-        if zone_state is not None and zone_state.volume_db == volume_db:
-            return True
+        # Callers that have already mutated zone_state optimistically (e.g.
+        # volume_up/volume_down on x20) must pass skip_if_redundant=False,
+        # otherwise this check short-circuits and the receiver is never told.
+        if skip_if_redundant:
+            zone_state = self._zone_states.get(zone)
+            if zone_state is not None and zone_state.volume_db == volume_db:
+                return True
         return await self.send_with_retry(
             self._get_zone_command(zone, const.CMD_VOLUME, volume_db),
             max_attempts=const.VOLUME_RETRY_MAX_ATTEMPTS,
@@ -567,7 +573,9 @@ class AnthemDevice(PersistentConnectionDevice):
         new_vol = min(0, current + 1)
         zone_state.volume_db = new_vol
         self.push_update()
-        return await self.set_volume(new_vol, zone)
+        # skip_if_redundant=False: the optimistic zone_state update above
+        # makes set_volume think it's already at new_vol. Force the send.
+        return await self.set_volume(new_vol, zone, skip_if_redundant=False)
 
     async def volume_down(self, zone: int = 1) -> bool:
         zone_state = self._zone_states[zone]
@@ -575,15 +583,21 @@ class AnthemDevice(PersistentConnectionDevice):
         new_vol = max(-90, current - 1)
         zone_state.volume_db = new_vol
         self.push_update()
-        return await self.set_volume(new_vol, zone)
+        # See volume_up for why skip_if_redundant=False.
+        return await self.set_volume(new_vol, zone, skip_if_redundant=False)
 
-    async def set_volume_percent(self, percent: int, zone: int = 1) -> bool:
+    async def set_volume_percent(
+        self, percent: int, zone: int = 1, skip_if_redundant: bool = True
+    ) -> bool:
         """Set volume as percentage (x40 series only)."""
         percent = max(0, min(100, percent))
-        # Skip no-op writes (same rationale as set_volume).
-        zone_state = self._zone_states.get(zone)
-        if zone_state is not None and zone_state.volume_pct == percent:
-            return True
+        # Skip no-op writes (same rationale as set_volume). No x40 caller
+        # mutates zone_state before calling this today, but the flag is
+        # exposed for symmetry with set_volume.
+        if skip_if_redundant:
+            zone_state = self._zone_states.get(zone)
+            if zone_state is not None and zone_state.volume_pct == percent:
+                return True
         return await self.send_with_retry(
             self._get_zone_command(zone, const.CMD_VOLUME_PERCENT, percent),
             max_attempts=const.VOLUME_RETRY_MAX_ATTEMPTS,

--- a/uc_intg_anthemav/media_player.py
+++ b/uc_intg_anthemav/media_player.py
@@ -13,6 +13,7 @@ from ucapi import StatusCodes
 from ucapi.media_player import Attributes, Commands, DeviceClasses, Features, MediaPlayer, States, Options
 from ucapi_framework import MediaPlayerEntity
 
+from uc_intg_anthemav import const
 from uc_intg_anthemav.config import AnthemDeviceConfig, ZoneConfig
 from uc_intg_anthemav.device import AnthemDevice
 
@@ -59,6 +60,7 @@ class AnthemMediaPlayer(MediaPlayerEntity):
                 Commands.VOLUME_UP,
                 Commands.VOLUME_DOWN,
                 Commands.MUTE_TOGGLE,
+                *const.VOLUME_DB_PRESETS.keys(),
             ]
         }
 
@@ -169,6 +171,11 @@ class AnthemMediaPlayer(MediaPlayerEntity):
                         return StatusCodes.OK if success else StatusCodes.SERVER_ERROR
                     return StatusCodes.BAD_REQUEST
                 return StatusCodes.BAD_REQUEST
+
+            elif cmd_id in const.VOLUME_DB_PRESETS:
+                target_db = const.VOLUME_DB_PRESETS[cmd_id]
+                success = await self._device.set_volume(target_db, zone)
+                return StatusCodes.OK if success else StatusCodes.SERVER_ERROR
 
             else:
                 _LOG.debug("[%s] Unsupported command: %s", self.id, cmd_id)


### PR DESCRIPTION
## Summary

- Adds 19 `VOLUME_DB_MINUS_*` / `VOLUME_DB_ZERO` simple_commands to the media_player entity (−90 dB to 0 dB in 5 dB steps), giving activities a way to target an exact dB via the UC command picker. Registered on every per-zone media_player so multi-zone setups route each preset to the correct zone.
- Adds `AnthemDevice.send_with_retry(command, max_attempts, delay)`, a general-purpose wrapper that retries commands the receiver rejects with `!E`. Correlation is by the echoed command string; registry is keyed per-command so parallel per-zone retries don't collide.
- `set_volume` / `set_volume_percent` opt into a 12 × 1 s budget via `VOLUME_RETRY_*` constants (empirically tuned on an MRX 540 — 8th retry succeeds ~7.2 s after `on` on cold-start). Generic wrapper default is a modest 3 × 0.5 s.
- Both volume setters also short-circuit no-op writes (skip sending when current state already matches target, avoiding pointless `!E` feedback loops).

## Why presets and not a parameterized command?

UC's activity-editor command picker only renders a numeric-value-entry field for built-in commands (`VOLUME`, `SELECT_SOURCE`, …). Custom `simple_commands` declared by an integration are parameterless string IDs, so a single "set volume to <dB>" command isn't expressible today. The preset set is the closest achievable UX.

## Test plan

- [x] Unit tests of the retry wrapper (tuple registry, per-call `delay`/`max_attempts`, give-up after exhaustion, non-registered `!E` left as warning, redundant-send short-circuit, `close_connection` clears registry).
- [x] On-device cold-start on MRX 540: activity fires `on` → `VOLUME_DB_MINUS_70` → `select_source`; retry loop runs for ~7 s, 8th attempt succeeds, front panel lands at −70 dB, percent slider and dB sensor both update.
- [x] On-device warm-receiver: same activity on an already-on receiver — no retries, no `!E`, volume jumps to target immediately.
- [x] Regression: percent slider, `VOLUME_UP`/`DOWN`, `MUTE_*`, `SELECT_SOURCE`, listening-mode, remote-page commands all unchanged.
- [ ] Multi-zone verification (not testable locally — no multi-zone hardware). Routing is by per-entity zone; retry registry is keyed by full command string (`Z1VOL-70` vs `Z2VOL-30`) so per-zone retries are independent.
- [ ] x20 series verification. Volume controls should be unaffected but we need verification that they aren't disrupted by the new state-checking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)