### PR TITLE
Fine-grained x40 volume up/down (0.5 dB step + sensor precision)

### DIFF
--- a/uc_intg_anthemav/device.py
+++ b/uc_intg_anthemav/device.py
@@ -539,7 +539,9 @@ class AnthemDevice(PersistentConnectionDevice):
             return self._model
         zone = self._zone_states[1]
         mapping = {
-            "volume": str(zone.volume_db) if zone.volume_db is not None else None,
+            # Always show one decimal so the half-dB precision is visible
+            # to the user even when the current value is integer-valued.
+            "volume": f"{zone.volume_db:.1f}" if zone.volume_db is not None else None,
             "audio_format": zone.audio_format if zone.audio_format != "Unknown" else None,
             "audio_channels": zone.audio_channels if zone.audio_channels != "Unknown" else None,
             "video_resolution": zone.video_resolution if zone.video_resolution != "Unknown" else None,
@@ -559,9 +561,9 @@ class AnthemDevice(PersistentConnectionDevice):
         )
 
     async def set_volume(
-        self, volume_db: int, zone: int = 1, skip_if_redundant: bool = True
+        self, volume_db: float, zone: int = 1, skip_if_redundant: bool = True
     ) -> bool:
-        volume_db = max(-90, min(10, volume_db))
+        volume_db = max(-90.0, min(10.0, volume_db))
         # Skip no-op writes: the receiver returns !E when asked to set to
         # its current value, which would otherwise trigger pointless retries.
         # Callers that have already mutated zone_state optimistically (e.g.
@@ -824,5 +826,11 @@ class AnthemDevice(PersistentConnectionDevice):
         return self._zone_states[zone]
 
     def _get_zone_command(self, zone: int, command: str, value: Any = "") -> str:
+        # Format floats canonically so integer-valued floats serialise the
+        # same as ints. This keeps the retry-registry key (Z1VOL-30) matching
+        # whether the value comes from a dB-preset send (int) or a state echo
+        # from the receiver (parsed as float).
+        if isinstance(value, float):
+            value = f"{value:g}"  # -30.0 -> "-30", -30.5 -> "-30.5"
         return f"{const.CMD_ZONE_PREFIX}{zone}{command}{value}"
 

--- a/uc_intg_anthemav/device.py
+++ b/uc_intg_anthemav/device.py
@@ -626,6 +626,26 @@ class AnthemDevice(PersistentConnectionDevice):
             self._get_zone_command(zone, const.CMD_VOLUME_PERCENT_DOWN)
         )
 
+    async def volume_up_step(self, zone: int = 1) -> bool:
+        """Volume up by the receiver's native VOL step (fire-and-forget).
+
+        Sends bare ``Z{zone}VUP;`` and lets the receiver pick the increment
+        — empirically 0.5 dB on x40, matching the Anthem IR remote.
+        """
+        return await self._send_command(
+            self._get_zone_command(zone, const.CMD_VOLUME_UP)
+        )
+
+    async def volume_down_step(self, zone: int = 1) -> bool:
+        """Volume down by the receiver's native VOL step (fire-and-forget).
+
+        Sends bare ``Z{zone}VDN;`` and lets the receiver pick the increment
+        — empirically 0.5 dB on x40, matching the Anthem IR remote.
+        """
+        return await self._send_command(
+            self._get_zone_command(zone, const.CMD_VOLUME_DOWN)
+        )
+
     async def set_mute(self, muted: bool, zone: int = 1) -> bool:
         return await self._send_command(
             self._get_zone_command(

--- a/uc_intg_anthemav/media_player.py
+++ b/uc_intg_anthemav/media_player.py
@@ -132,14 +132,17 @@ class AnthemMediaPlayer(MediaPlayerEntity):
 
             elif cmd_id == Commands.VOLUME_UP:
                 if self._device.is_x40_series:
-                    success = await self._device.volume_up_percent(zone)
+                    # Fire-and-forget VUP — receiver steps by its native VOL
+                    # increment (0.5 dB on MRX 540), matching the IR remote.
+                    success = await self._device.volume_up_step(zone)
                 else:
                     success = await self._device.volume_up(zone)
                 return StatusCodes.OK if success else StatusCodes.SERVER_ERROR
 
             elif cmd_id == Commands.VOLUME_DOWN:
                 if self._device.is_x40_series:
-                    success = await self._device.volume_down_percent(zone)
+                    # See VOLUME_UP for rationale.
+                    success = await self._device.volume_down_step(zone)
                 else:
                     success = await self._device.volume_down(zone)
                 return StatusCodes.OK if success else StatusCodes.SERVER_ERROR

--- a/uc_intg_anthemav/models.py
+++ b/uc_intg_anthemav/models.py
@@ -14,7 +14,7 @@ class ZoneState:
     """Represents the state of a single zone."""
 
     power: Optional[bool] = None
-    volume_db: Optional[int] = None
+    volume_db: Optional[float] = None  # 0.5 dB resolution on x40
     volume_pct: Optional[int] = None
     muted: Optional[bool] = None
     input_number: Optional[int] = None
@@ -75,9 +75,9 @@ class ZonePower(ZoneMessage):
 
 @dataclass
 class ZoneVolume(ZoneMessage):
-    """Zone volume in dB (ZxVOL)."""
+    """Zone volume in dB (ZxVOL). Float to preserve 0.5 dB resolution."""
 
-    volume_db: int
+    volume_db: float
 
 
 @dataclass

--- a/uc_intg_anthemav/parser.py
+++ b/uc_intg_anthemav/parser.py
@@ -81,9 +81,11 @@ def parse_message(response: str) -> Optional[ParsedMessage]:
                 return ZoneVolumePercent(zone=zone_num, volume_pct=int(pvol_match.group(1)))
 
         if const.RESP_VOLUME in payload:
-            vol_match = re.search(rf"{const.RESP_VOLUME}(-?\d+)", payload)
+            # Receiver pushes dB at 0.5 dB resolution on x40 (per Anthem v5
+            # spec). Capture the optional fractional part instead of dropping it.
+            vol_match = re.search(rf"{const.RESP_VOLUME}(-?\d+(?:\.\d+)?)", payload)
             if vol_match:
-                return ZoneVolume(zone=zone_num, volume_db=int(vol_match.group(1)))
+                return ZoneVolume(zone=zone_num, volume_db=float(vol_match.group(1)))
 
         if const.RESP_MUTE in payload:
             return ZoneMute(zone=zone_num, is_muted=const.VAL_ON in payload)


### PR DESCRIPTION
## Summary

On the x40 series (MRX 540/740/1140, AVM 70/90), the standard UC `VOLUME_UP` / `VOLUME_DOWN` commands previously sent `Z1PVUP` / `Z1PVDN` (percent step, ~0.9 dB per press). This PR routes those commands through bare `Z1VUP` / `Z1VDN` instead, which the receiver answers with a 0.5 dB step — matching the Anthem IR remote's behaviour.

A second commit widens the receive path to preserve the 0.5 dB precision: the parser previously truncated fractional VOL values to integer, so the dB volume sensor appeared stuck across alternate presses. With the precision fix, the sensor now correctly reads `-30.5`, `-30.0`, `-29.5`, … as the user steps.

Verified on an MRX 540 (firmware HD.80/00.04): no `!I`/`!E`/`!R` responses, front panel increments by 0.5 dB per press exactly as the IR remote does, and the UC sensor reflects each half-step.

## Changes

**Send side — finer step on x40:**
- New `volume_up_step` / `volume_down_step` methods on `AnthemDevice` that send the bare `Z{zone}VUP;` / `Z{zone}VDN;` commands. Pure fire-and-forget — no state read, no state write.
- `media_player.py` x40 branches of `VOLUME_UP` / `VOLUME_DOWN` now call the new helpers.
- `volume_up_percent` / `volume_down_percent` are retained (not removed) in case any out-of-tree code depends on them.

**Receive side — 0.5 dB precision through to the sensor:**
- `parser.py` regex captures the optional fractional part; casts to `float`.
- `ZoneState.volume_db` and `ZoneVolume.volume_db` typed as `float` / `Optional[float]`.
- `set_volume` signature accepts `float`.
- `_get_zone_command` formats floats with `{:g}` so integer-valued floats serialise the same as ints on the wire — preserving the v2.2.0 retry-registry drain semantics (registry keys registered as `Z1VOL-30` continue to match echoes parsed as `-30.0`).
- dB sensor uses `{:.1f}` formatting so the displayed value always shows half-dB precision (`-30.0`, `-30.5`).

**x20 path untouched.** Continues to use the state-aware `volume_up()` / `volume_down()` path that sends `Z{zone}VOL{current ± 1}` at integer dB step.

## Test plan

- [x] Cold-start activity firing VOLUME_UP/DOWN — no errors, front panel steps 0.5 dB per press.
- [x] Repeated rapid presses (UC button held) — clean 0.5 dB stepping.
- [x] UC dB sensor reflects fractional values empirically (e.g., `-30.5`, `-30.0`).
- [x] Regression: percent slider, dB presets (VOLUME_DB_*), mute, source select all unchanged.
- [x] Local unit tests covering parser, format, retry-registry drain round-trip (int send + float echo).
- [ ] x20 verification (no hardware locally) — code path untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
